### PR TITLE
ThemeSelector cookie support

### DIFF
--- a/.changeset/calm-forks-cross.md
+++ b/.changeset/calm-forks-cross.md
@@ -1,0 +1,5 @@
+---
+"@cloudmix-dev/react": patch
+---
+
+Release 0.0.13

--- a/packages/react/src/components/theme-selector.tsx
+++ b/packages/react/src/components/theme-selector.tsx
@@ -18,10 +18,11 @@ function getThemePreference(key?: string): Theme {
 }
 
 export interface ThemeSelectorProps {
+  cookie?: string;
   localStorageKey?: string;
 }
 
-function ThemeSelector({ localStorageKey }: ThemeSelectorProps) {
+function ThemeSelector({ cookie, localStorageKey }: ThemeSelectorProps) {
   const [theme, setTheme] = useState<Theme>(
     getThemePreference(localStorageKey),
   );
@@ -30,6 +31,10 @@ function ThemeSelector({ localStorageKey }: ThemeSelectorProps) {
 
     if (localStorageKey) {
       window.localStorage.setItem(localStorageKey, theme.toString());
+    }
+
+    if (cookie) {
+      document.cookie = `${cookie}=${theme.toString()};path=/`;
     }
   };
 

--- a/packages/react/src/components/theme-selector.tsx
+++ b/packages/react/src/components/theme-selector.tsx
@@ -19,10 +19,15 @@ function getThemePreference(key?: string): Theme {
 
 export interface ThemeSelectorProps {
   cookie?: string;
+  cookieMaxAge?: number;
   localStorageKey?: string;
 }
 
-function ThemeSelector({ cookie, localStorageKey }: ThemeSelectorProps) {
+function ThemeSelector({
+  cookie,
+  cookieMaxAge = 31536000,
+  localStorageKey,
+}: ThemeSelectorProps) {
   const [theme, setTheme] = useState<Theme>(
     getThemePreference(localStorageKey),
   );
@@ -34,7 +39,7 @@ function ThemeSelector({ cookie, localStorageKey }: ThemeSelectorProps) {
     }
 
     if (cookie) {
-      document.cookie = `${cookie}=${theme.toString()};path=/`;
+      document.cookie = `${cookie}=${theme.toString()};path=/;max-age=${cookieMaxAge};`;
     }
   };
 

--- a/www/storybook/src/stories/theme-selector.stories.tsx
+++ b/www/storybook/src/stories/theme-selector.stories.tsx
@@ -18,10 +18,23 @@ const meta: Meta<typeof ThemeSelector> = {
 
 export default meta;
 
-export const Default = {};
+export const Default = {
+  args: {
+    cookie: "",
+    localStorageKey: "",
+  },
+};
 
 export const WithLocalStorageKey = {
   args: {
+    cookie: "",
     localStorageKey: "theme",
+  },
+};
+
+export const WithCookie = {
+  args: {
+    cookie: "_theme",
+    localStorageKey: "",
   },
 };


### PR DESCRIPTION
This PR adds cookie support to the `ThemeSelector` component via a `cookie` prop, as well as `max-age` support via a `cookieMaxAge` prop