### PR TITLE
Fix mono fonts tailwind

### DIFF
--- a/.changeset/mighty-planets-burn.md
+++ b/.changeset/mighty-planets-burn.md
@@ -1,0 +1,5 @@
+---
+"@cloudmix-dev/tailwind": patch
+---
+
+Release 0.0.14

--- a/packages/tailwind/src/config.ts
+++ b/packages/tailwind/src/config.ts
@@ -41,7 +41,7 @@ export function config(config?: Config) {
         plugin(({ addComponents }) => {
           const text = {
             color: colors.zinc[50],
-            fontFamilt: ["Source Code Pro", ...defaultTheme.fontFamily.mono],
+            fontFamily: ["Source Code Pro", ...defaultTheme.fontFamily.mono],
           };
           const muted = {
             color: colors.zinc[300],


### PR DESCRIPTION
This PR fixes a bug where the monospace fonts for Prism rendered code were not applied properly