### PR TITLE
Fix Code component styling within Prose component

### DIFF
--- a/.changeset/giant-trees-trade.md
+++ b/.changeset/giant-trees-trade.md
@@ -1,0 +1,5 @@
+---
+"@cloudmix-dev/react": patch
+---
+
+Fix Code component rendering within Prose component

--- a/packages/react/src/components/code.tsx
+++ b/packages/react/src/components/code.tsx
@@ -36,7 +36,7 @@ function Code({ content, copy, fileExplorer, language, numbers }: CodeProps) {
   };
 
   return (
-    <div className="relative p-4 bg-neutral-900 rounded-lg font-mono ring-1 ring-neutral-700">
+    <div className="not-prose relative p-4 bg-neutral-900 rounded-lg font-mono ring-1 ring-neutral-700">
       <div className="absolute -top-px left-20 right-11 h-px bg-gradient-to-r from-brand-300/0 via-brand-300/70 to-brand-300/0 dark:from-brand-700/0 dark:via-brand-700/50 dark:to-brand-700/0" />
       <div className="absolute -bottom-px left-11 right-20 h-px bg-gradient-to-r from-brand-400/0 via-brand-400 to-brand-400/0 dark:from-brand-600/0 dark:via-brand-600/70 dark:to-brand-600/0" />
       {fileExplorer && (


### PR DESCRIPTION
This PR fixes a bug where a `Code` component rendered within a `Prose` component would not render properly