### PR TITLE
Ensure Prism styles aren't stripped from Tailwind output

### DIFF
--- a/.changeset/calm-boats-bake.md
+++ b/.changeset/calm-boats-bake.md
@@ -1,0 +1,5 @@
+---
+"@cloudmix-dev/react": patch
+---
+
+Ensure Prism styles aren't stripped from Tailwind output

--- a/packages/tailwind/src/config.ts
+++ b/packages/tailwind/src/config.ts
@@ -13,6 +13,11 @@ export function config(config?: Config) {
         "./node_modules/@cloudmix-dev/react/**/*.js",
         "./src/**/*.{astro,html,md,mdx,tsx}",
       ],
+      safelist: [
+        {
+          pattern: /(token|loader|language-)/,
+        },
+      ],
       darkMode: "class",
       theme: {
         colors: {
@@ -97,7 +102,7 @@ export function config(config?: Config) {
             ".token.punctuation": dark,
             ".token.attr-equals": dark,
             ".token.unit": teal,
-            ".language-css .token.functiont": teal,
+            ".language-css .token.function": teal,
             ".token.number": orange,
             // Temporary override of Sonner styles
             ".loader": {


### PR DESCRIPTION
This PR updates the default Tailwind config to **not** strip Prism classes from the final output, even if they aren't directly used within the codebase