### PR TITLE
Fix Excalidraw imports

### DIFF
--- a/.changeset/soft-pumpkins-shout.md
+++ b/.changeset/soft-pumpkins-shout.md
@@ -1,0 +1,5 @@
+---
+"@cloudmix-dev/react": patch
+---
+
+Fix Excalidraw imports

--- a/packages/react/src/components/excalidraw-diagram.tsx
+++ b/packages/react/src/components/excalidraw-diagram.tsx
@@ -1,12 +1,11 @@
-import {
-  Excalidraw,
-  THEME,
-  convertToExcalidrawElements,
-} from "@excalidraw/excalidraw";
-import { parseMermaidToExcalidraw } from "@excalidraw/mermaid-to-excalidraw";
+import * as excalidraw from "@excalidraw/excalidraw";
+import * as excalidrawMermaid from "@excalidraw/mermaid-to-excalidraw";
 
 import { useEffect, useRef, useState } from "react";
 import { cn } from "../utils";
+
+const { Excalidraw, THEME, convertToExcalidrawElements } = excalidraw;
+const { parseMermaidToExcalidraw } = excalidrawMermaid;
 
 export interface ExcalidrawDiagramProps {
   className?: string;


### PR DESCRIPTION
This PR fixes the `@excalidraw/*` imports as they are currently CommonJS **only**.